### PR TITLE
Add settings page for SDC Weather API key

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,0 +1,76 @@
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register plugin settings, section, and fields.
+ */
+function sdc_weather_register_settings() {
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_api_key',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '',
+        )
+    );
+
+    add_settings_section(
+        'sdc_weather_section',
+        __( 'API Settings', 'sdc-weather' ),
+        '__return_false',
+        'sdc_weather'
+    );
+
+    add_settings_field(
+        'sdc_weather_api_key',
+        __( 'API Key', 'sdc-weather' ),
+        'sdc_weather_api_key_field',
+        'sdc_weather',
+        'sdc_weather_section'
+    );
+}
+add_action( 'admin_init', 'sdc_weather_register_settings' );
+
+/**
+ * Output the API key input field.
+ */
+function sdc_weather_api_key_field() {
+    $value = get_option( 'sdc_weather_api_key', '' );
+    echo '<input type="text" name="sdc_weather_api_key" value="' . esc_attr( $value ) . '" class="regular-text" />';
+}
+
+/**
+ * Add the SDC Weather settings page under Settings.
+ */
+function sdc_weather_add_admin_menu() {
+    add_options_page(
+        __( 'SDC Weather', 'sdc-weather' ),
+        __( 'SDC Weather', 'sdc-weather' ),
+        'manage_options',
+        'sdc_weather',
+        'sdc_weather_settings_page'
+    );
+}
+add_action( 'admin_menu', 'sdc_weather_add_admin_menu' );
+
+/**
+ * Render the settings page.
+ */
+function sdc_weather_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'SDC Weather', 'sdc-weather' ); ?></h1>
+        <form action="options.php" method="post">
+            <?php
+            settings_fields( 'sdc_weather' );
+            do_settings_sections( 'sdc_weather' );
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}

--- a/sdc-weather.php
+++ b/sdc-weather.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: SDC Weather
+ * Description: Weather information plugin.
+ * Version: 1.0.0
+ * Author: SDC
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Load settings.
+require_once plugin_dir_path( __FILE__ ) . 'includes/settings.php';


### PR DESCRIPTION
## Summary
- add settings page with API key input under Settings
- load settings file in plugin bootstrap

## Testing
- `php -l sdc-weather.php`
- `php -l includes/settings.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3c7b73f38832c96939eed4722de8f