### PR TITLE
Add base color and warning logic to weather widget

### DIFF
--- a/weather-widget.php
+++ b/weather-widget.php
@@ -11,6 +11,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Get the AccuWeather icon URL for a given icon code.
+ *
+ * @param int|string $code AccuWeather icon code.
+ * @return string Icon URL.
+ */
+function cww_get_accuweather_icon_url( $code ) {
+    if ( '' === $code ) {
+        return '';
+    }
+
+    $code = str_pad( absint( $code ), 2, '0', STR_PAD_LEFT );
+
+    return sprintf( 'https://developer.accuweather.com/sites/default/files/%s-s.png', $code );
+}
+
+/**
  * Render the weather widget shortcode.
  *
  * @return string HTML output for the widget.
@@ -27,18 +43,23 @@ function cww_render_weather_widget() {
 
     $temperature = isset( $data['temperature'] ) ? floatval( $data['temperature'] ) : 0;
     $condition   = isset( $data['condition'] ) ? $data['condition'] : '';
-    $icon        = isset( $data['icon'] ) ? $data['icon'] : '';
+    $icon_code   = isset( $data['icon'] ) ? $data['icon'] : '';
 
-    $threshold = get_option( 'weather_widget_temperature_threshold', 90 );
+    $base_color = get_option( 'sdc_weather_color', '#000000' );
+    $threshold  = get_option( 'sdc_weather_temp_threshold', 0 );
     $is_warning = $temperature > $threshold;
 
     if ( $is_warning ) {
-        $icon = plugin_dir_url( __FILE__ ) . 'warning.svg';
+        $icon  = plugin_dir_url( __FILE__ ) . 'warning.svg';
+        $color = '#ff0000';
+    } else {
+        $icon  = cww_get_accuweather_icon_url( $icon_code );
+        $color = $base_color;
     }
 
     $classes = 'weather-widget' . ( $is_warning ? ' warning' : '' );
 
-    $html  = '<div class="' . esc_attr( $classes ) . '">';
+    $html  = '<div class="' . esc_attr( $classes ) . '" style="color:' . esc_attr( $color ) . '">';
     if ( ! empty( $icon ) ) {
         $html .= '<img class="weather-icon" width="27" height="27" src="' . esc_url( $icon ) . '" alt="' . esc_attr( $condition ) . '" />';
     }


### PR DESCRIPTION
## Summary
- Retrieve widget color and threshold from plugin settings
- Map AccuWeather icon codes to image URLs and replace with local warning icon when temperature exceeds threshold
- Apply widget text color inline, switching to red on warnings

## Testing
- `php -l weather-widget.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3ca449c38832c9b99ba289c34e33a