### PR TITLE
Add typography options and font loading

### DIFF
--- a/assets/css/widget.css
+++ b/assets/css/widget.css
@@ -1,0 +1,1 @@
+/* Typography styles for weather widget */

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -48,6 +48,66 @@ function sdc_weather_register_settings() {
         )
     );
 
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_font_source',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '',
+        )
+    );
+
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_font_family',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => 'Proxima Nova',
+        )
+    );
+
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_adobe_kit',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '',
+        )
+    );
+
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_uploaded_font',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'esc_url_raw',
+            'default'           => '',
+        )
+    );
+
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_font_size',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '16pt',
+        )
+    );
+
+    register_setting(
+        'sdc_weather',
+        'sdc_weather_font_weight',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '400',
+        )
+    );
+
     add_settings_section(
         'sdc_weather_section',
         __( 'SDC Weather Settings', 'sdc-weather' ),
@@ -86,6 +146,61 @@ function sdc_weather_register_settings() {
         'sdc_weather',
         'sdc_weather_section'
     );
+
+    add_settings_section(
+        'sdc_weather_typography',
+        __( 'Typography', 'sdc-weather' ),
+        '__return_false',
+        'sdc_weather'
+    );
+
+    add_settings_field(
+        'sdc_weather_font_source',
+        __( 'Font Source', 'sdc-weather' ),
+        'sdc_weather_font_source_field',
+        'sdc_weather',
+        'sdc_weather_typography'
+    );
+
+    add_settings_field(
+        'sdc_weather_font_family',
+        __( 'Font Family', 'sdc-weather' ),
+        'sdc_weather_font_family_field',
+        'sdc_weather',
+        'sdc_weather_typography'
+    );
+
+    add_settings_field(
+        'sdc_weather_adobe_kit',
+        __( 'Adobe Kit ID', 'sdc-weather' ),
+        'sdc_weather_adobe_kit_field',
+        'sdc_weather',
+        'sdc_weather_typography'
+    );
+
+    add_settings_field(
+        'sdc_weather_uploaded_font',
+        __( 'Uploaded Font URL', 'sdc-weather' ),
+        'sdc_weather_uploaded_font_field',
+        'sdc_weather',
+        'sdc_weather_typography'
+    );
+
+    add_settings_field(
+        'sdc_weather_font_size',
+        __( 'Font Size', 'sdc-weather' ),
+        'sdc_weather_font_size_field',
+        'sdc_weather',
+        'sdc_weather_typography'
+    );
+
+    add_settings_field(
+        'sdc_weather_font_weight',
+        __( 'Font Weight', 'sdc-weather' ),
+        'sdc_weather_font_weight_field',
+        'sdc_weather',
+        'sdc_weather_typography'
+    );
 }
 add_action( 'admin_init', 'sdc_weather_register_settings' );
 
@@ -119,6 +234,68 @@ function sdc_weather_temp_threshold_field() {
 function sdc_weather_api_key_field() {
     $value = get_option( 'sdc_weather_api_key', '' );
     echo '<input type="text" name="sdc_weather_api_key" value="' . esc_attr( $value ) . '" class="regular-text" />';
+}
+
+/**
+ * Output the font source field.
+ */
+function sdc_weather_font_source_field() {
+    $value   = get_option( 'sdc_weather_font_source', '' );
+    $options = array(
+        'google' => __( 'Google', 'sdc-weather' ),
+        'adobe'  => __( 'Adobe', 'sdc-weather' ),
+        'upload' => __( 'Upload', 'sdc-weather' ),
+    );
+    echo '<select name="sdc_weather_font_source">';
+    foreach ( $options as $key => $label ) {
+        printf(
+            '<option value="%1$s" %2$s>%3$s</option>',
+            esc_attr( $key ),
+            selected( $value, $key, false ),
+            esc_html( $label )
+        );
+    }
+    echo '</select>';
+}
+
+/**
+ * Output the font family field.
+ */
+function sdc_weather_font_family_field() {
+    $value = get_option( 'sdc_weather_font_family', 'Proxima Nova' );
+    echo '<input type="text" name="sdc_weather_font_family" value="' . esc_attr( $value ) . '" class="regular-text" />';
+}
+
+/**
+ * Output the Adobe kit ID field.
+ */
+function sdc_weather_adobe_kit_field() {
+    $value = get_option( 'sdc_weather_adobe_kit', '' );
+    echo '<input type="text" name="sdc_weather_adobe_kit" value="' . esc_attr( $value ) . '" class="regular-text" />';
+}
+
+/**
+ * Output the uploaded font URL field.
+ */
+function sdc_weather_uploaded_font_field() {
+    $value = get_option( 'sdc_weather_uploaded_font', '' );
+    echo '<input type="text" name="sdc_weather_uploaded_font" value="' . esc_attr( $value ) . '" class="regular-text" />';
+}
+
+/**
+ * Output the font size field.
+ */
+function sdc_weather_font_size_field() {
+    $value = get_option( 'sdc_weather_font_size', '16pt' );
+    echo '<input type="text" name="sdc_weather_font_size" value="' . esc_attr( $value ) . '" class="small-text" />';
+}
+
+/**
+ * Output the font weight field.
+ */
+function sdc_weather_font_weight_field() {
+    $value = get_option( 'sdc_weather_font_weight', '400' );
+    echo '<input type="number" name="sdc_weather_font_weight" value="' . esc_attr( $value ) . '" class="small-text" />';
 }
 
 /**

--- a/sdc-weather.php
+++ b/sdc-weather.php
@@ -13,3 +13,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Load settings.
 require_once plugin_dir_path( __FILE__ ) . 'includes/settings-page.php';
+
+add_action( 'wp_enqueue_scripts', 'sdc_weather_enqueue_typography' );
+
+/**
+ * Enqueue typography styles for the weather widget.
+ */
+function sdc_weather_enqueue_typography() {
+    $font_source   = get_option( 'sdc_weather_font_source', '' );
+    $font_family   = get_option( 'sdc_weather_font_family', 'Proxima Nova' );
+    $font_size     = get_option( 'sdc_weather_font_size', '16pt' );
+    $font_weight   = get_option( 'sdc_weather_font_weight', '400' );
+    $adobe_kit     = get_option( 'sdc_weather_adobe_kit', '' );
+    $uploaded_font = get_option( 'sdc_weather_uploaded_font', '' );
+
+    wp_register_style( 'sdc-weather-widget', plugin_dir_url( __FILE__ ) . 'assets/css/widget.css', array(), '1.0.0' );
+    wp_enqueue_style( 'sdc-weather-widget' );
+
+    $css = '';
+
+    if ( 'google' === $font_source && ! empty( $font_family ) ) {
+        $google_url = 'https://fonts.googleapis.com/css?family=' . urlencode( $font_family );
+        if ( ! empty( $font_weight ) ) {
+            $google_url .= ':' . esc_attr( $font_weight );
+        }
+        wp_enqueue_style( 'sdc-weather-google-font', $google_url, array(), null );
+    } elseif ( 'adobe' === $font_source && ! empty( $adobe_kit ) ) {
+        wp_enqueue_style( 'sdc-weather-adobe-font', 'https://use.typekit.net/' . trim( $adobe_kit ) . '.css', array(), null );
+    } elseif ( 'upload' === $font_source && ! empty( $uploaded_font ) ) {
+        $css .= "@font-face { font-family: 'sdc-weather-upload'; src: url('" . esc_url( $uploaded_font ) . "') format('woff2'); font-weight: normal; font-style: normal; }";
+        $font_family = 'sdc-weather-upload';
+    }
+
+    $css .= '.weather-widget { font-family: ' . esc_attr( $font_family ) . '; font-size: ' . esc_attr( $font_size ) . '; font-weight: ' . esc_attr( $font_weight ) . '; }';
+
+    wp_add_inline_style( 'sdc-weather-widget', $css );
+}


### PR DESCRIPTION
## Summary
- extend settings page with typography section covering font source, family, size and weight
- enqueue Google, Adobe or uploaded fonts and inject widget typography CSS with Proxima Nova default

## Testing
- `php -l includes/settings-page.php`
- `php -l sdc-weather.php`
- `php -l weather-widget.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3ca413048832c89c065f65bce0543