### PR TITLE
Add test suite for API client and shortcode

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -1,0 +1,35 @@
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+/**
+ * Retrieve weather data for a location, using transient caching.
+ *
+ * @param string $location Location to retrieve weather for.
+ * @return array|false Parsed weather data or false on failure.
+ */
+function sdc_weather_get_weather( $location ) {
+    $cache_key = 'sdc_weather_' . md5( strtolower( $location ) );
+    $cached    = get_transient( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    $api_key = get_option( 'sdc_weather_api_key', '' );
+    $url     = 'https://api.example.com/weather?location=' . rawurlencode( $location ) . '&key=' . $api_key;
+
+    $response = wp_remote_get( $url );
+    if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
+        return false;
+    }
+
+    $data = json_decode( $response['body'], true );
+    set_transient( $cache_key, $data, HOUR_IN_SECONDS );
+    return $data;
+}

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -1,0 +1,29 @@
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Shortcode handler for [sdc_weather].
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string Rendered HTML.
+ */
+function sdc_weather_render_shortcode( $atts ) {
+    $atts = shortcode_atts(
+        array(
+            'location' => '',
+        ),
+        $atts,
+        'sdc_weather'
+    );
+
+    $data = sdc_weather_get_weather( $atts['location'] );
+    if ( ! is_array( $data ) || ! isset( $data['temp'] ) ) {
+        return '';
+    }
+
+    return '<div class="sdc-weather">Temperature: ' . esc_html( $data['temp'] ) . '</div>';
+}
+add_shortcode( 'sdc_weather', 'sdc_weather_render_shortcode' );

--- a/sdc-weather.php
+++ b/sdc-weather.php
@@ -13,3 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Load settings.
 require_once plugin_dir_path( __FILE__ ) . 'includes/settings.php';
+// Load API client and shortcode.
+require_once plugin_dir_path( __FILE__ ) . 'includes/api.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/shortcode.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,120 @@
+<?php
+define( 'ABSPATH', true );
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+// Option storage.
+$GLOBALS['wp_options'] = array();
+function get_option( $name, $default = false ) {
+    return array_key_exists( $name, $GLOBALS['wp_options'] ) ? $GLOBALS['wp_options'][ $name ] : $default;
+}
+function update_option( $name, $value ) {
+    $GLOBALS['wp_options'][ $name ] = $value;
+}
+
+// Transient storage.
+$GLOBALS['wp_transients'] = array();
+function get_transient( $key ) {
+    if ( isset( $GLOBALS['wp_transients'][ $key ] ) ) {
+        $item = $GLOBALS['wp_transients'][ $key ];
+        if ( $item['expiration'] >= time() ) {
+            return $item['value'];
+        }
+    }
+    return false;
+}
+function set_transient( $key, $value, $expiration ) {
+    $GLOBALS['wp_transients'][ $key ] = array(
+        'value'      => $value,
+        'expiration' => time() + $expiration,
+    );
+}
+function delete_transient( $key ) {
+    unset( $GLOBALS['wp_transients'][ $key ] );
+}
+
+// Filter system.
+$GLOBALS['wp_filter'] = array();
+function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+    $GLOBALS['wp_filter'][ $tag ][] = $function_to_add;
+}
+function apply_filters( $tag, $value ) {
+    $args = func_get_args();
+    array_shift( $args );
+    array_shift( $args );
+    if ( isset( $GLOBALS['wp_filter'][ $tag ] ) ) {
+        foreach ( $GLOBALS['wp_filter'][ $tag ] as $callback ) {
+            $value = $callback( $value, ...$args );
+        }
+    }
+    return $value;
+}
+
+function wp_remote_get( $url ) {
+    $response = apply_filters( 'pre_http_request', null, array( 'url' => $url ) );
+    if ( null !== $response ) {
+        return $response;
+    }
+    return array( 'body' => '' );
+}
+function is_wp_error( $thing ) {
+    return false;
+}
+
+// Shortcode system.
+$GLOBALS['shortcode_tags'] = array();
+function add_shortcode( $tag, $func ) {
+    $GLOBALS['shortcode_tags'][ $tag ] = $func;
+}
+function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
+    return array_merge( $pairs, $atts );
+}
+function do_shortcode( $content ) {
+    return preg_replace_callback( '/\[(\w+)([^\]]*)\]/', function ( $matches ) {
+        $tag = $matches[1];
+        if ( ! isset( $GLOBALS['shortcode_tags'][ $tag ] ) ) {
+            return $matches[0];
+        }
+        $atts_string = trim( $matches[2] );
+        $atts       = array();
+        if ( preg_match_all( '/(\w+)="([^"]*)"/', $atts_string, $attr_matches, PREG_SET_ORDER ) ) {
+            foreach ( $attr_matches as $attr ) {
+                $atts[ $attr[1] ] = $attr[2];
+            }
+        }
+        return call_user_func( $GLOBALS['shortcode_tags'][ $tag ], $atts );
+    }, $content );
+}
+
+function esc_html( $text ) {
+    return htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_attr( $text ) {
+    return $text;
+}
+function sanitize_text_field( $text ) {
+    return $text;
+}
+function __( $text, $domain = '' ) {
+    return $text;
+}
+function esc_html_e( $text, $domain = '' ) {
+    echo esc_html( $text );
+}
+function plugin_dir_path( $file ) {
+    return __DIR__ . '/../';
+}
+function add_options_page() {}
+function register_setting() {}
+function add_settings_section() {}
+function add_settings_field() {}
+function add_action() {}
+function settings_fields() {}
+function do_settings_sections() {}
+function submit_button() {}
+
+// Load plugin files needed for tests.
+require_once __DIR__ . '/../includes/api.php';
+require_once __DIR__ . '/../includes/shortcode.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="SDC Weather Tests">
+            <directory suffix=".php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/test-api-client.php
+++ b/tests/test-api-client.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ApiClientTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['wp_options']    = array();
+        $GLOBALS['wp_transients'] = array();
+        $GLOBALS['wp_filter']     = array();
+        $GLOBALS['shortcode_tags'] = array();
+    }
+
+    public function test_caches_responses() {
+        $GLOBALS['wp_options']['sdc_weather_api_key'] = 'abc123';
+        $calls = 0;
+        add_filter( 'pre_http_request', function( $pre, $args ) use ( &$calls ) {
+            $calls++;
+            return array( 'body' => json_encode( array( 'temp' => 70 ) ) );
+        }, 10, 2 );
+
+        $first  = sdc_weather_get_weather( 'London' );
+        $second = sdc_weather_get_weather( 'London' );
+
+        $this->assertSame( 1, $calls, 'Expected only one HTTP request due to caching.' );
+        $this->assertSame( $first, $second );
+    }
+}

--- a/tests/test-option-defaults.php
+++ b/tests/test-option-defaults.php
@@ -1,0 +1,15 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class OptionDefaultsTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['wp_options']    = array();
+        $GLOBALS['wp_transients'] = array();
+        $GLOBALS['wp_filter']     = array();
+        $GLOBALS['shortcode_tags'] = array();
+    }
+
+    public function test_api_key_default_empty() {
+        $this->assertSame( '', get_option( 'sdc_weather_api_key', '' ) );
+    }
+}

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ShortcodeTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['wp_options']    = array();
+        $GLOBALS['wp_transients'] = array();
+        $GLOBALS['wp_filter']     = array();
+        $GLOBALS['shortcode_tags'] = array();
+        // Re-register shortcode after resetting tags.
+        add_shortcode( 'sdc_weather', 'sdc_weather_render_shortcode' );
+    }
+
+    public function test_shortcode_renders_temperature() {
+        add_filter( 'pre_http_request', function( $pre, $args ) {
+            return array( 'body' => json_encode( array( 'temp' => 55 ) ) );
+        }, 10, 2 );
+
+        $output = do_shortcode( '[sdc_weather location="Paris"]' );
+        $this->assertSame( '<div class="sdc-weather">Temperature: 55</div>', $output );
+    }
+}


### PR DESCRIPTION
## Summary
- Implement weather API client with transient caching
- Add shortcode renderer for displaying weather data
- Configure PHPUnit and add tests for options, caching, and shortcode output

## Testing
- `phpunit -c tests/phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68a3c954fd28832c9d0196e0b3e5578a