### PR TITLE
Load weather widget and API client early

### DIFF
--- a/sdc-weather.php
+++ b/sdc-weather.php
@@ -11,9 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Load settings and API client.
-require_once plugin_dir_path( __FILE__ ) . 'includes/settings-page.php';
+// Load core functionality early.
 require_once plugin_dir_path( __FILE__ ) . 'includes/api-client.php';
+require_once plugin_dir_path( __FILE__ ) . 'weather-widget.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/settings-page.php';
 
 add_action( 'wp_enqueue_scripts', 'sdc_weather_enqueue_typography' );
 


### PR DESCRIPTION
## Summary
- Load API client and weather widget during plugin bootstrap to expose shortcode and weather functions early

## Testing
- `php -l sdc-weather.php weather-widget.php includes/api-client.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3d1a7e2b8832c99c93a5327b6bf72