### PR TITLE
Remove redundant plugin header from weather widget

### DIFF
--- a/weather-widget.php
+++ b/weather-widget.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Plugin Name: Custom Weather Widget
- * Description: Displays current weather information via shortcode.
- * Version: 1.0.0
- * Author: OpenAI Assistant
- */
+
+// Weather widget shortcode and related functions.
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;


### PR DESCRIPTION
## Summary
- Remove duplicate plugin header from `weather-widget.php` so main header exists only in `sdc-weather.php`

## Testing
- `php -l weather-widget.php`
- `php -l sdc-weather.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3d358b2f4832ca1aeca26fab56ed8