### PR TITLE
Use media uploader for font selection

### DIFF
--- a/assets/js/font-upload.js
+++ b/assets/js/font-upload.js
@@ -1,0 +1,22 @@
+jQuery(function($){
+    var frame;
+    $('#sdc_weather_uploaded_font_button').on('click', function(e){
+        e.preventDefault();
+        if (frame) {
+            frame.open();
+            return;
+        }
+        frame = wp.media({
+            title: 'Select Font',
+            button: { text: 'Use this font' },
+            library: { type: ['font/otf','font/ttf','font/woff','font/woff2','application/x-font-ttf','application/vnd.ms-fontobject','application/font-woff','application/font-woff2'] },
+            multiple: false
+        });
+        frame.on('select', function(){
+            var attachment = frame.state().get('selection').first().toJSON();
+            $('#sdc_weather_uploaded_font').val(attachment.id);
+            $('#sdc_weather_uploaded_font_filename').text(attachment.filename);
+        });
+        frame.open();
+    });
+});

--- a/sdc-weather.php
+++ b/sdc-weather.php
@@ -22,12 +22,13 @@ add_action( 'wp_enqueue_scripts', 'sdc_weather_enqueue_typography' );
  * Enqueue typography styles for the weather widget.
  */
 function sdc_weather_enqueue_typography() {
-    $font_source   = get_option( 'sdc_weather_font_source', '' );
-    $font_family   = get_option( 'sdc_weather_font_family', 'Proxima Nova' );
-    $font_size     = get_option( 'sdc_weather_font_size', '16pt' );
-    $font_weight   = get_option( 'sdc_weather_font_weight', '400' );
-    $adobe_kit     = get_option( 'sdc_weather_adobe_kit', '' );
-    $uploaded_font = get_option( 'sdc_weather_uploaded_font', '' );
+    $font_source       = get_option( 'sdc_weather_font_source', '' );
+    $font_family       = get_option( 'sdc_weather_font_family', 'Proxima Nova' );
+    $font_size         = get_option( 'sdc_weather_font_size', '16pt' );
+    $font_weight       = get_option( 'sdc_weather_font_weight', '400' );
+    $adobe_kit         = get_option( 'sdc_weather_adobe_kit', '' );
+    $uploaded_font_id  = get_option( 'sdc_weather_uploaded_font', 0 );
+    $uploaded_font_url = $uploaded_font_id ? wp_get_attachment_url( $uploaded_font_id ) : '';
 
     wp_register_style( 'sdc-weather-widget', plugin_dir_url( __FILE__ ) . 'assets/css/widget.css', array(), '1.0.0' );
     wp_enqueue_style( 'sdc-weather-widget' );
@@ -42,8 +43,18 @@ function sdc_weather_enqueue_typography() {
         wp_enqueue_style( 'sdc-weather-google-font', $google_url, array(), null );
     } elseif ( 'adobe' === $font_source && ! empty( $adobe_kit ) ) {
         wp_enqueue_style( 'sdc-weather-adobe-font', 'https://use.typekit.net/' . trim( $adobe_kit ) . '.css', array(), null );
-    } elseif ( 'upload' === $font_source && ! empty( $uploaded_font ) ) {
-        $css .= "@font-face { font-family: 'sdc-weather-upload'; src: url('" . esc_url( $uploaded_font ) . "') format('woff2'); font-weight: normal; font-style: normal; }";
+    } elseif ( 'upload' === $font_source && ! empty( $uploaded_font_url ) ) {
+        $mime   = get_post_mime_type( $uploaded_font_id );
+        $format = 'woff2';
+        if ( in_array( $mime, array( 'font/ttf', 'application/x-font-ttf' ), true ) ) {
+            $format = 'truetype';
+        } elseif ( 'font/otf' === $mime ) {
+            $format = 'opentype';
+        } elseif ( in_array( $mime, array( 'font/woff', 'application/font-woff' ), true ) ) {
+            $format = 'woff';
+        }
+
+        $css        .= "@font-face { font-family: 'sdc-weather-upload'; src: url('" . esc_url( $uploaded_font_url ) . "') format('" . esc_attr( $format ) . "'); font-weight: normal; font-style: normal; }";
         $font_family = 'sdc-weather-upload';
     }
 


### PR DESCRIPTION
## Summary
- Replace custom font URL field with media uploader storing attachment IDs
- Sanitize uploaded font attachments and enqueue media scripts in settings page
- Load uploaded fonts in front-end by resolving attachment URL and applying @font-face

## Testing
- `php -l includes/settings-page.php`
- `php -l sdc-weather.php`


------
https://chatgpt.com/codex/tasks/task_b_68a3d5ad29f8832cac30f4a53e3dc1ac