### PR TITLE
Add PHPUnit tests for weather plugin

### DIFF
--- a/tests/WeatherPluginTest.php
+++ b/tests/WeatherPluginTest.php
@@ -1,0 +1,59 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class WeatherPluginTest extends TestCase {
+    protected function setUp(): void {
+        global $wp_options, $transients, $wp_remote_get_calls, $mock_body, $registered_settings;
+        $wp_options = array();
+        $transients = array();
+        $registered_settings = array();
+        $wp_remote_get_calls = 0;
+        $mock_body = '';
+    }
+
+    public function test_default_settings_registered() {
+        sdc_weather_register_settings();
+        global $registered_settings;
+        $this->assertSame('#000000', $registered_settings['sdc_weather_color']['default']);
+        $this->assertSame(0, $registered_settings['sdc_weather_temp_threshold']['default']);
+        $this->assertSame('Proxima Nova', $registered_settings['sdc_weather_font_family']['default']);
+    }
+
+    public function test_api_response_is_cached() {
+        global $wp_options, $mock_body, $wp_remote_get_calls;
+        $wp_options['sdc_weather_api_key'] = 'abc';
+        $wp_options['sdc_weather_location'] = '123';
+        $mock_body = json_encode(array(array(
+            'WeatherText' => 'Sunny',
+            'WeatherIcon' => 1,
+            'Temperature' => array('Imperial' => array('Value' => 75)),
+        )));
+
+        $first = fetch_current_weather();
+        $this->assertSame(array('condition' => 'Sunny', 'icon' => 1, 'temperature' => 75), $first);
+        $this->assertSame(1, $wp_remote_get_calls);
+
+        $second = fetch_current_weather();
+        $this->assertSame($first, $second);
+        $this->assertSame(1, $wp_remote_get_calls, 'API should not be called when using cache');
+    }
+
+    public function test_shortcode_output_with_mocked_http() {
+        global $wp_options, $mock_body;
+        $wp_options['sdc_weather_api_key'] = 'key';
+        $wp_options['sdc_weather_location'] = 'loc';
+        $wp_options['sdc_weather_color'] = '#00ff00';
+        $wp_options['sdc_weather_temp_threshold'] = 70;
+        $mock_body = json_encode(array(array(
+            'WeatherText' => 'Cloudy',
+            'WeatherIcon' => 2,
+            'Temperature' => array('Imperial' => array('Value' => 65)),
+        )));
+
+        $html = cww_render_weather_widget();
+        $this->assertStringContainsString('class="weather-widget"', $html);
+        $this->assertStringContainsString('Cloudy 65&deg;', $html);
+        $this->assertStringContainsString('color:#00ff00', $html);
+        $this->assertStringContainsString('02-s.png', $html);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,84 @@
+<?php
+// Define minimal WordPress-like environment for tests.
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+
+// Globals for storing options and transients.
+$GLOBALS['wp_options'] = array();
+$GLOBALS['transients'] = array();
+$GLOBALS['registered_settings'] = array();
+$GLOBALS['wp_remote_get_calls'] = 0;
+$GLOBALS['mock_body'] = '';
+
+// Option handling.
+function get_option($name, $default = false) {
+    global $wp_options;
+    return array_key_exists($name, $wp_options) ? $wp_options[$name] : $default;
+}
+function update_option($name, $value) {
+    global $wp_options;
+    $wp_options[$name] = $value;
+}
+
+// Settings registration.
+function register_setting($group, $name, $args = array()) {
+    global $registered_settings;
+    $registered_settings[$name] = $args;
+}
+function add_settings_section() {}
+function add_settings_field() {}
+
+// Sanitizers.
+function sanitize_text_field($value) { return $value; }
+function sanitize_hex_color($value) { return $value; }
+function absint($value) { return (int) $value; }
+function esc_url_raw($value) { return $value; }
+function __($text) { return $text; }
+
+// Escapers.
+function esc_attr($text) { return $text; }
+function esc_html($text) { return $text; }
+function esc_url($text) { return $text; }
+
+// Shortcodes.
+function add_shortcode($tag, $func) {}
+
+// Transients.
+function set_transient($key, $value, $expiration) {
+    global $transients;
+    $transients[$key] = $value;
+    return true;
+}
+function get_transient($key) {
+    global $transients;
+    return array_key_exists($key, $transients) ? $transients[$key] : false;
+}
+
+// HTTP API mock.
+function wp_remote_get($url) {
+    global $mock_body, $wp_remote_get_calls;
+    $wp_remote_get_calls++;
+    return array('body' => $mock_body);
+}
+function wp_remote_retrieve_body($response) {
+    return $response['body'];
+}
+function is_wp_error($response) {
+    return false;
+}
+
+// Misc.
+function plugin_dir_url($file) {
+    return '/';
+}
+
+// Load plugin files.
+require_once __DIR__ . '/../includes/api-client.php';
+require_once __DIR__ . '/../weather-widget.php';
+require_once __DIR__ . '/../includes/settings-page.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="bootstrap.php">
+    <testsuites>
+        <testsuite name="SDC Weather Tests">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and bootstrap harness
- cover default option registration
- test API response caching and shortcode rendering with mocked HTTP

## Testing
- `phpunit -c tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3d778006c832c9d7e2caca1113117