### PR TITLE
Add temperature unit setting and unit tests

### DIFF
--- a/includes/api-client.php
+++ b/includes/api-client.php
@@ -54,10 +54,17 @@ function fetch_current_weather( $location = '' ) {
         return array();
     }
 
+    $unit = get_option( 'sdc_weather_temp_unit', 'celsius' );
+    if ( 'fahrenheit' === $unit ) {
+        $temp = isset( $current['Temperature']['Imperial']['Value'] ) ? $current['Temperature']['Imperial']['Value'] : '';
+    } else {
+        $temp = isset( $current['Temperature']['Metric']['Value'] ) ? $current['Temperature']['Metric']['Value'] : '';
+    }
+
     $result = array(
         'condition'   => isset( $current['WeatherText'] ) ? $current['WeatherText'] : '',
         'icon'        => isset( $current['WeatherIcon'] ) ? $current['WeatherIcon'] : '',
-        'temperature' => isset( $current['Temperature']['Imperial']['Value'] ) ? $current['Temperature']['Imperial']['Value'] : '',
+        'temperature' => $temp,
     );
 
     set_transient( $transient_key, $result, HOUR_IN_SECONDS );
@@ -114,10 +121,17 @@ function sdc_weather_test_connection( $location, $api_key ) {
         return $error;
     }
 
+    $unit = get_option( 'sdc_weather_temp_unit', 'celsius' );
+    if ( 'fahrenheit' === $unit ) {
+        $temp = isset( $current['Temperature']['Imperial']['Value'] ) ? $current['Temperature']['Imperial']['Value'] : '';
+    } else {
+        $temp = isset( $current['Temperature']['Metric']['Value'] ) ? $current['Temperature']['Metric']['Value'] : '';
+    }
+
     $result = array(
         'condition'   => isset( $current['WeatherText'] ) ? $current['WeatherText'] : '',
         'icon'        => isset( $current['WeatherIcon'] ) ? $current['WeatherIcon'] : '',
-        'temperature' => isset( $current['Temperature']['Imperial']['Value'] ) ? $current['Temperature']['Imperial']['Value'] : '',
+        'temperature' => $temp,
     );
 
     set_transient( $transient_key, $result, defined( 'MINUTE_IN_SECONDS' ) ? 5 * MINUTE_IN_SECONDS : 300 );

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -20,6 +20,16 @@ function sdc_weather_register_settings() {
 
     register_setting(
         'sdc_weather',
+        'sdc_weather_temp_unit',
+        array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => 'celsius',
+        )
+    );
+
+    register_setting(
+        'sdc_weather',
         'sdc_weather_temp_threshold',
         array(
             'type'              => 'integer',
@@ -54,6 +64,14 @@ function sdc_weather_register_settings() {
     );
 
     add_settings_field(
+        'sdc_weather_temp_unit',
+        __( 'Temperature Unit', 'sdc-weather' ),
+        'sdc_weather_temp_unit_field',
+        'sdc_weather',
+        'sdc_weather_section'
+    );
+
+    add_settings_field(
         'sdc_weather_temp_threshold',
         __( 'Temperature Threshold', 'sdc-weather' ),
         'sdc_weather_temp_threshold_field',
@@ -77,6 +95,17 @@ add_action( 'admin_init', 'sdc_weather_register_settings' );
 function sdc_weather_location_field() {
     $value = get_option( 'sdc_weather_location', '' );
     echo '<input type="text" name="sdc_weather_location" value="' . esc_attr( $value ) . '" class="regular-text" />';
+}
+
+/**
+ * Output the temperature unit select field.
+ */
+function sdc_weather_temp_unit_field() {
+    $value = get_option( 'sdc_weather_temp_unit', 'celsius' );
+    echo '<select name="sdc_weather_temp_unit">';
+    echo '<option value="celsius"' . ( 'celsius' === $value ? ' selected="selected"' : '' ) . '>Celsius</option>';
+    echo '<option value="fahrenheit"' . ( 'fahrenheit' === $value ? ' selected="selected"' : '' ) . '>Fahrenheit</option>';
+    echo '</select>';
 }
 
 /**
@@ -132,7 +161,9 @@ function sdc_weather_settings_page() {
                 if ( ! empty( $icon ) ) {
                     echo '<img class="weather-icon" width="27" height="27" src="' . esc_url( $icon ) . '" alt="' . esc_attr( $connection['condition'] ) . '" /> ';
                 }
-                echo '<span class="weather-text">' . esc_html( $connection['condition'] ) . ' ' . esc_html( $connection['temperature'] ) . '&deg;</span>';
+                $unit   = get_option( 'sdc_weather_temp_unit', 'celsius' );
+                $symbol = ( 'fahrenheit' === $unit ) ? '&deg;F' : '&deg;C';
+                echo '<span class="weather-text">' . esc_html( $connection['condition'] ) . ' ' . esc_html( $connection['temperature'] ) . $symbol . '</span>';
                 echo '</div>';
             }
             echo '</div>';

--- a/tests/WeatherPluginTest.php
+++ b/tests/WeatherPluginTest.php
@@ -15,6 +15,7 @@ class WeatherPluginTest extends TestCase {
         sdc_weather_register_settings();
         global $registered_settings;
         $this->assertSame('', $registered_settings['sdc_weather_location']['default']);
+        $this->assertSame('celsius', $registered_settings['sdc_weather_temp_unit']['default']);
         $this->assertSame(0, $registered_settings['sdc_weather_temp_threshold']['default']);
         $this->assertSame('', $registered_settings['sdc_weather_api_key']['default']);
     }
@@ -23,10 +24,14 @@ class WeatherPluginTest extends TestCase {
         global $wp_options, $mock_body, $wp_remote_get_calls;
         $wp_options['sdc_weather_api_key'] = 'abc';
         $wp_options['sdc_weather_location'] = '123';
+        $wp_options['sdc_weather_temp_unit'] = 'fahrenheit';
         $mock_body = json_encode(array(array(
             'WeatherText' => 'Sunny',
             'WeatherIcon' => 1,
-            'Temperature' => array('Imperial' => array('Value' => 75)),
+            'Temperature' => array(
+                'Imperial' => array('Value' => 75),
+                'Metric'   => array('Value' => 24),
+            ),
         )));
 
         $first = fetch_current_weather();
@@ -38,20 +43,64 @@ class WeatherPluginTest extends TestCase {
         $this->assertSame(1, $wp_remote_get_calls, 'API should not be called when using cache');
     }
 
+    public function test_fetch_current_weather_celsius() {
+        global $wp_options, $mock_body;
+        $wp_options['sdc_weather_api_key'] = 'abc';
+        $wp_options['sdc_weather_location'] = '123';
+        $wp_options['sdc_weather_temp_unit'] = 'celsius';
+        $mock_body = json_encode(array(array(
+            'WeatherText' => 'Sunny',
+            'WeatherIcon' => 1,
+            'Temperature' => array(
+                'Imperial' => array('Value' => 75),
+                'Metric'   => array('Value' => 24),
+            ),
+        )));
+
+        $data = fetch_current_weather();
+        $this->assertSame(array('condition' => 'Sunny', 'icon' => 1, 'temperature' => 24), $data);
+    }
+
     public function test_shortcode_output_with_mocked_http() {
         global $wp_options, $mock_body;
         $wp_options['sdc_weather_api_key'] = 'key';
         $wp_options['sdc_weather_location'] = 'loc';
         $wp_options['sdc_weather_temp_threshold'] = 70;
+        $wp_options['sdc_weather_temp_unit'] = 'fahrenheit';
         $mock_body = json_encode(array(array(
             'WeatherText' => 'Cloudy',
             'WeatherIcon' => 2,
-            'Temperature' => array('Imperial' => array('Value' => 65)),
+            'Temperature' => array(
+                'Imperial' => array('Value' => 65),
+                'Metric'   => array('Value' => 18),
+            ),
         )));
 
         $html = cww_render_weather_widget();
         $this->assertStringContainsString('class="weather-widget"', $html);
-        $this->assertStringContainsString('Cloudy 65&deg;', $html);
+        $this->assertStringContainsString('Cloudy 65&deg;F', $html);
+        $this->assertStringNotContainsString('style=', $html);
+        $this->assertStringContainsString('02-s.png', $html);
+    }
+
+    public function test_shortcode_output_with_mocked_http_celsius() {
+        global $wp_options, $mock_body;
+        $wp_options['sdc_weather_api_key'] = 'key';
+        $wp_options['sdc_weather_location'] = 'loc';
+        $wp_options['sdc_weather_temp_threshold'] = 70;
+        $wp_options['sdc_weather_temp_unit'] = 'celsius';
+        $mock_body = json_encode(array(array(
+            'WeatherText' => 'Cloudy',
+            'WeatherIcon' => 2,
+            'Temperature' => array(
+                'Imperial' => array('Value' => 65),
+                'Metric'   => array('Value' => 18),
+            ),
+        )));
+
+        $html = cww_render_weather_widget();
+        $this->assertStringContainsString('class="weather-widget"', $html);
+        $this->assertStringContainsString('Cloudy 18&deg;C', $html);
         $this->assertStringNotContainsString('style=', $html);
         $this->assertStringContainsString('02-s.png', $html);
     }

--- a/weather-widget.php
+++ b/weather-widget.php
@@ -56,7 +56,9 @@ function cww_render_weather_widget() {
     if ( ! empty( $icon ) ) {
         $html .= '<img class="weather-icon" width="27" height="27" src="' . esc_url( $icon ) . '" alt="' . esc_attr( $condition ) . '" />';
     }
-    $html .= '<span class="weather-text">' . esc_html( $condition ) . ' ' . esc_html( $temperature ) . '&deg;</span>';
+    $unit   = get_option( 'sdc_weather_temp_unit', 'celsius' );
+    $symbol = ( 'fahrenheit' === $unit ) ? 'F' : 'C';
+    $html .= '<span class="weather-text">' . esc_html( $condition ) . ' ' . esc_html( $temperature ) . '&deg;' . $symbol . '</span>';
     $html .= '</div>';
 
     return $html;


### PR DESCRIPTION
## Summary
- allow choosing Celsius or Fahrenheit and display the correct unit everywhere
- fetch weather data in the selected unit
- expand unit tests for both Celsius and Fahrenheit

## Testing
- `php -l includes/settings-page.php`
- `php -l includes/api-client.php`
- `php -l weather-widget.php`
- `php -l tests/WeatherPluginTest.php`
- `./vendor/bin/phpunit -c tests/phpunit.xml` *(fails: No such file or directory)*
- `phpunit -c tests/phpunit.xml` *(fails: command not found)*
- `composer require --dev phpunit/phpunit --quiet` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a443088b64832c8248508a3f9943f0